### PR TITLE
Dselans/repopulate wasm and live fix

### DIFF
--- a/apis/grpcapi/external.go
+++ b/apis/grpcapi/external.go
@@ -240,6 +240,11 @@ func (s *ExternalServer) UpdatePipeline(ctx context.Context, req *protos.UpdateP
 		return util.StandardResponse(ctx, protos.ResponseCode_RESPONSE_CODE_INTERNAL_SERVER_ERROR, err.Error()), nil
 	}
 
+	// Re-populate WASM bytes (since they are stripped for UI)
+	if err := util.PopulateWASMFields(req.Pipeline, s.Options.Config.WASMDir); err != nil {
+		return util.StandardResponse(ctx, protos.ResponseCode_RESPONSE_CODE_INTERNAL_SERVER_ERROR, errors.Wrap(err, "unable to repopulate WASM data")), nil
+	}
+
 	// Update pipeline in storage
 	if err := s.Options.StoreService.UpdatePipeline(ctx, req.Pipeline); err != nil {
 		return util.StandardResponse(ctx, protos.ResponseCode_RESPONSE_CODE_INTERNAL_SERVER_ERROR, err.Error()), nil

--- a/apis/grpcapi/external.go
+++ b/apis/grpcapi/external.go
@@ -242,7 +242,7 @@ func (s *ExternalServer) UpdatePipeline(ctx context.Context, req *protos.UpdateP
 
 	// Re-populate WASM bytes (since they are stripped for UI)
 	if err := util.PopulateWASMFields(req.Pipeline, s.Options.Config.WASMDir); err != nil {
-		return util.StandardResponse(ctx, protos.ResponseCode_RESPONSE_CODE_INTERNAL_SERVER_ERROR, errors.Wrap(err, "unable to repopulate WASM data")), nil
+		return util.StandardResponse(ctx, protos.ResponseCode_RESPONSE_CODE_INTERNAL_SERVER_ERROR, errors.Wrap(err, "unable to repopulate WASM data").Error()), nil
 	}
 
 	// Update pipeline in storage

--- a/apis/grpcapi/external.go
+++ b/apis/grpcapi/external.go
@@ -82,15 +82,13 @@ func (s *ExternalServer) getAllLive(ctx context.Context) ([]*protos.LiveInfo, er
 				continue
 			}
 
-			if v.Audience == nil {
-				s.log.Errorf("getAllLive: audience is nil for session id '%s'", v.SessionID)
-				continue
-			}
+			// There might be no audience - service name + node name etc. should be in ClientInfo though!
 
 			live.Client = v.Value
-			live.Client.XSessionId = &v.SessionID
-			live.Client.XServiceName = &v.Audience.ServiceName
-			live.Client.XNodeName = &v.NodeName
+
+			liveInfo = append(liveInfo, live)
+
+			// Audiences will get filled out later
 		}
 	}
 
@@ -101,9 +99,9 @@ func (s *ExternalServer) getAllLive(ctx context.Context) ([]*protos.LiveInfo, er
 
 	// Have register entries - fill out audiences for each
 	for _, li := range liveInfo {
-		// Find all live entry audiences with same session ID
+		// Find all live entry audiences with same session ID (and are NOT register)
 		for _, ld := range liveData {
-			if *li.Client.XSessionId == ld.SessionID {
+			if *li.Client.XSessionId == ld.SessionID && !ld.Register {
 				li.Audiences = append(li.Audiences, ld.Audience)
 			}
 		}

--- a/services/store/store.go
+++ b/services/store/store.go
@@ -102,6 +102,11 @@ func (s *Store) AddRegistration(ctx context.Context, req *protos.RegisterRequest
 
 	registrationKey := NATSLiveKey(req.SessionId, s.options.NodeName, "register")
 
+	// Populate these so we can save them in K/V; needed for GetAll()
+	req.ClientInfo.XSessionId = &req.SessionId
+	req.ClientInfo.XServiceName = &req.ServiceName
+	req.ClientInfo.XNodeName = &s.options.NodeName
+
 	clientInfoBytes, err := proto.Marshal(req.ClientInfo)
 	if err != nil {
 		return errors.Wrap(err, "error marshalling client info")
@@ -502,7 +507,7 @@ func (s *Store) GetLive(ctx context.Context) ([]*types.LiveEntry, error) {
 
 	// key is of the format:
 	//
-	// <sessionID>/<nodeName>/<<service>/<operation_type>/<component>>
+	// <sessionID>/<nodeName>/<<service>/<operation_type>/<operation_name>/<component_name>>
 	// OR
 	// <sessionID>/<nodeName>/register
 

--- a/test-utils/demo-client/register.go
+++ b/test-utils/demo-client/register.go
@@ -99,7 +99,7 @@ func (r *Register) runFileReader() error {
 
 		for scanner.Scan() {
 			r.inputCh <- scanner.Bytes()
-			time.Sleep(time.Millisecond * 100)
+			time.Sleep(time.Second)
 		}
 
 		llog.Debug("reached end of file; restarting")


### PR DESCRIPTION
1. Fix bug in `UpdatePipeline()` - re-populates WASM fields
2. Fix bug w/ missing live info in `GetAll()` (needed to save service name as part of client info)

cc @jacobheric 
