### PR TITLE
allow auth-token

### DIFF
--- a/assets/envoy/envoy.yaml
+++ b/assets/envoy/envoy.yaml
@@ -31,7 +31,7 @@ static_resources:
                       allow_origin_string_match:
                         - prefix: "*"
                       allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                      allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                      allow_headers: auth-token,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                       max_age: "1728000"
                       expose_headers: custom-header-1,grpc-status,grpc-message
               http_filters:


### PR DESCRIPTION
Normally I do all data fetching from the snitch server via server side deno from the browser, but for grpc server streaming this would introduce an awkward/inefficient handoff or stream transform...so I'm streaming directly from the browser. In order to get this to work though I had to update the cors policy to permit the auth header.