### PR TITLE
adds the "send initial KV command(s)" functionality

### DIFF
--- a/apis/grpcapi/external_test.go
+++ b/apis/grpcapi/external_test.go
@@ -823,6 +823,7 @@ func runServer() {
 		NotifyService:   d.NotifyService,
 		NATSBackend:     d.NATSBackend,
 		PubSubService:   d.PubSubService,
+		KVService:       d.KVService,
 	})
 
 	if err != nil {

--- a/apis/grpcapi/grpcapi.go
+++ b/apis/grpcapi/grpcapi.go
@@ -17,6 +17,7 @@ import (
 	"github.com/streamdal/snitch-server/config"
 	"github.com/streamdal/snitch-server/services/bus"
 	"github.com/streamdal/snitch-server/services/cmd"
+	"github.com/streamdal/snitch-server/services/kv"
 	"github.com/streamdal/snitch-server/services/metrics"
 	"github.com/streamdal/snitch-server/services/notify"
 	"github.com/streamdal/snitch-server/services/pubsub"
@@ -51,6 +52,7 @@ type Options struct {
 	NotifyService   notify.INotifier
 	NATSBackend     natty.INatty
 	PubSubService   pubsub.IPubSub
+	KVService       kv.IKV
 }
 
 func New(o *Options) (*GRPCAPI, error) {
@@ -222,6 +224,10 @@ func validateOptions(o *Options) error {
 
 	if o.PubSubService == nil {
 		return errors.New("options.PubSubService cannot be nil")
+	}
+
+	if o.KVService == nil {
+		return errors.New("options.KVService cannot be nil")
 	}
 
 	return nil

--- a/apis/grpcapi/internal.go
+++ b/apis/grpcapi/internal.go
@@ -19,6 +19,10 @@ import (
 	"github.com/streamdal/snitch-server/validate"
 )
 
+const (
+	MaxKVCommandSizeBytes = 64 * 1024 // 64KB
+)
+
 // InternalServer implements the internal GRPC API interface
 type InternalServer struct {
 	GRPCAPI
@@ -453,7 +457,7 @@ func (s *InternalServer) generateInitialKVCommands(ctx context.Context) ([]*prot
 
 	// Inject up to 64KB of instructions per KVCommand
 	for _, kv := range kvs {
-		if size > 64*1024 {
+		if size > MaxKVCommandSizeBytes {
 			// Copy instructions
 			instructionsCopy := make([]*protos.KVInstruction, len(instructions))
 			copy(instructionsCopy, instructions)

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func run(d *deps.Dependencies) error {
 			NotifyService:   d.NotifyService,
 			NATSBackend:     d.NATSBackend,
 			PubSubService:   d.PubSubService,
+			KVService:       d.KVService,
 		})
 		if err != nil {
 			errChan <- errors.Wrap(err, "error during gRPC API setup")


### PR DESCRIPTION
@blinktag I forgot to add this last KV part to the snitch-server.

This will send all KVs to a client on register. I am batching the number of instructions a KVCommand contains based on size (64KB per batch).

Tested CREATE/DELETE/UPDATE with updated snitch-go-client.