### PR TITLE
Dselans/space fixes

### DIFF
--- a/apis/grpcapi/internal.go
+++ b/apis/grpcapi/internal.go
@@ -100,6 +100,10 @@ func (s *InternalServer) Register(request *protos.RegisterRequest, server protos
 		"session_id":   request.SessionId,
 	})
 
+	for _, aud := range request.Audiences {
+		s.log.Debugf("register request with audience: %+v", aud)
+	}
+
 	// Store registration
 	if err := s.Options.StoreService.AddRegistration(server.Context(), request); err != nil {
 		return errors.Wrap(err, "unable to save registration")

--- a/apis/grpcapi/internal.go
+++ b/apis/grpcapi/internal.go
@@ -100,10 +100,6 @@ func (s *InternalServer) Register(request *protos.RegisterRequest, server protos
 		"session_id":   request.SessionId,
 	})
 
-	for _, aud := range request.Audiences {
-		s.log.Debugf("register request with audience: %+v", aud)
-	}
-
 	// Store registration
 	if err := s.Options.StoreService.AddRegistration(server.Context(), request); err != nil {
 		return errors.Wrap(err, "unable to save registration")
@@ -117,8 +113,6 @@ func (s *InternalServer) Register(request *protos.RegisterRequest, server protos
 	} else {
 		llog.Debugf("channel already exists for session id '%s'", request.SessionId)
 	}
-
-	llog.Debug("beginning register cmd loop")
 
 	var (
 		shutdown    bool
@@ -144,7 +138,7 @@ func (s *InternalServer) Register(request *protos.RegisterRequest, server protos
 
 	// Send all KVs to client
 	go func() {
-		llog.Debugf("starting initial KV sync")
+		llog.Debug("starting initial KV sync")
 
 		kvCommands, err := s.generateInitialKVCommands(server.Context())
 		if err != nil {
@@ -164,7 +158,7 @@ func (s *InternalServer) Register(request *protos.RegisterRequest, server protos
 			}
 		}
 
-		llog.Debugf("finished initial KV sync")
+		llog.Debug("finished initial KV sync")
 	}()
 
 	// Listen for cmds from external API; forward them to connected clients

--- a/services/store/store.go
+++ b/services/store/store.go
@@ -438,6 +438,10 @@ func (s *Store) AddAudience(ctx context.Context, req *protos.NewAudienceRequest)
 	llog := s.log.WithField("method", "AddAudience")
 	llog.Debug("received request to add audience")
 
+	audStr := util.AudienceToStr(req.Audience)
+
+	s.log.Debugf("audience contents: %+v; audience as str: %s", req.Audience, audStr)
+
 	// Add it to the live bucket
 	if err := s.options.RedisBackend.Set(
 		ctx,

--- a/test-utils/demo-client/cli.go
+++ b/test-utils/demo-client/cli.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strings"
 
 	"github.com/alecthomas/kong"
 )
@@ -64,19 +63,6 @@ func ParseArgs() (*Config, error) {
 }
 
 func validateRegisterArgs(cfg *Config) error {
-	// Replace spaces with underscores
-	cfg.Register.OperationName = strings.Replace(cfg.Register.OperationName, " ", "_", -1)
-	cfg.Register.ComponentName = strings.Replace(cfg.Register.ComponentName, " ", "_", -1)
-
-	// Are either valid?
-	if !ValidNameRegex.MatchString(cfg.Register.OperationName) {
-		return fmt.Errorf("invalid operation name (re: /^[a-zA-Z0-9_-]+$/): %s", cfg.Register.OperationName)
-	}
-
-	if !ValidNameRegex.MatchString(cfg.Register.ComponentName) {
-		return fmt.Errorf("invalid component name (re: /^[a-zA-Z0-9_-]+$/): %s", cfg.Register.ComponentName)
-	}
-
 	//// If input tye is file - ensure file was actually provided
 	//if cfg.Register.ConsumerInputType == "file" && cfg.Register.ConsumerInputFile == nil {
 	//	return fmt.Errorf("consumer input type is 'file' but no file was provided")

--- a/test-utils/demo-client/register.go
+++ b/test-utils/demo-client/register.go
@@ -131,8 +131,6 @@ func (r *Register) runClient() error {
 		return errors.Wrap(err, "failed to create snitch client")
 	}
 
-	llog.Debug("after instantiation")
-
 	for {
 		if r.config.Register.ConsumerInputType == "none" {
 			llog.Debug("no input data, nothing to do - noop")
@@ -142,6 +140,8 @@ func (r *Register) runClient() error {
 
 		// Consumer will have input - read input data
 		input := <-r.inputCh
+
+		fmt.Println("component name: ", r.config.Register.ComponentName)
 
 		resp, err := sc.Process(context.Background(), &snitch.ProcessRequest{
 			ComponentName: r.config.Register.ComponentName,

--- a/test-utils/demo-client/register.go
+++ b/test-utils/demo-client/register.go
@@ -141,8 +141,6 @@ func (r *Register) runClient() error {
 		// Consumer will have input - read input data
 		input := <-r.inputCh
 
-		fmt.Println("component name: ", r.config.Register.ComponentName)
-
 		resp, err := sc.Process(context.Background(), &snitch.ProcessRequest{
 			ComponentName: r.config.Register.ComponentName,
 			OperationType: snitch.OperationType(r.config.Register.OperationType),

--- a/util/util.go
+++ b/util/util.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
+	"github.com/streamdal/snitch-protos/build/go/protos/shared"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/streamdal/snitch-protos/build/go/protos"
@@ -85,8 +86,6 @@ func AudienceToStr(audience *protos.Audience) string {
 	}
 
 	str := strings.ToLower(fmt.Sprintf("%s:%s:%s:%s", audience.ServiceName, audience.OperationType, audience.OperationName, audience.ComponentName))
-
-	str = strings.Replace(str, " ", NormalizeSpace, -1)
 
 	return str
 }

--- a/util/util.go
+++ b/util/util.go
@@ -12,14 +12,12 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"github.com/streamdal/snitch-protos/build/go/protos"
-	"github.com/streamdal/snitch-protos/build/go/protos/shared"
 
 	"github.com/streamdal/snitch-server/wasm"
 )
 
 const (
 	GRPCRequestIDMetadataKey = "request-id"
-	NormalizeSpace           = "__SPACE__"
 )
 
 func GenerateUUID() string {
@@ -92,22 +90,12 @@ func AudienceToStr(audience *protos.Audience) string {
 
 // AudienceFromStr will parse a string into an Audience. If the string is invalid,
 // nil will be returned.
-//
-// Normalization explanation: Audience is stored in string format as part of the
-// key name in RedisBackend. This means that it must adhere to [a-zA-Z0-9_-]+. To
-// support spaces, we need to normalize the string before storage and
-// de-normalize it on reads. Because there are various funcs and methods that
-// parse the key as-is from RedisBackend, we cannot use something like base58 to encode &
-// decode the whole string and instead have to rely on str replaces.
-// ^ This applies to AudienceToStr() as well.
 func AudienceFromStr(s string) *protos.Audience {
 	if s == "" {
 		return nil
 	}
 
-	normalizedAudience := strings.Replace(s, NormalizeSpace, " ", -1)
-
-	parts := strings.Split(normalizedAudience, ":")
+	parts := strings.Split(s, ":")
 	if len(parts) != 4 {
 		return nil
 	}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -41,6 +41,10 @@ func RegisterRequest(req *protos.RegisterRequest) error {
 		return ErrInvalidCharacters("SessionId")
 	}
 
+	if !ValidCharactersRegex.MatchString(req.ServiceName) {
+		return ErrInvalidCharacters("SessionId")
+	}
+
 	// OK to not have audiences, but if defined, they must contain valid entries
 	for _, v := range req.Audiences {
 		if err := Audience(v); err != nil {
@@ -108,8 +112,16 @@ func Audience(audience *protos.Audience) error {
 		return ErrEmptyField("Audience.ServiceName")
 	}
 
+	if !ValidCharactersRegex.MatchString(audience.ServiceName) {
+		return ErrInvalidCharacters("audience.ServiceName")
+	}
+
 	if audience.ComponentName == "" {
 		return ErrEmptyField("Audience.ComponentName")
+	}
+
+	if !ValidCharactersRegex.MatchString(audience.ComponentName) {
+		return ErrInvalidCharacters("audience.ComponentName")
 	}
 
 	if audience.OperationType == protos.OperationType_OPERATION_TYPE_UNSET {
@@ -118,6 +130,10 @@ func Audience(audience *protos.Audience) error {
 
 	if audience.OperationName == "" {
 		return ErrEmptyField("Audience.OperationName")
+	}
+
+	if !ValidCharactersRegex.MatchString(audience.OperationName) {
+		return ErrInvalidCharacters("audience.OperationName")
 	}
 
 	return nil
@@ -186,10 +202,6 @@ func Pipeline(p *protos.Pipeline, requireId bool) error {
 
 	if p.Name == "" {
 		return ErrEmptyField("Name")
-	}
-
-	if !ValidCharactersRegex.MatchString(p.Name) {
-		return ErrInvalidCharacters("p.Name")
 	}
 
 	if len(p.Steps) == 0 {


### PR DESCRIPTION
These are "updates" not fixes.

Paste from a commit:

```
no need for any of the normalization stuff for Audience elements
If we allow spaces/non-[a-zA-Z0-9_-]+ for Audience elements, all SDKs
will have to know how to deal with such characters as well which would
be a huge pain in the ass. It is easier for us to enforce [a-zA-Z0-9-_]+
for now and avoid the whole space hassle.

The biggest pain was not allowing spaces for pipeline and step names and
that has been updated - so we should be good.
```

