### PR TITLE
Broadcast/consume TailResponse events over unique redis stream

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	SessionTTL           time.Duration    `help:"TTL for session keys in RedisBackend live K/V bucket" default:"5s"`
 	WASMDir              string           `help:"Directory where WASM files are stored" default:"./assets/wasm"`
 	SeedDummyData        bool             `help:"Seed RedisBackend with dummy data for testing" default:"false"`
+	NumTailConsumers     int              `help:"Number of tail consumers to run" default:"2"`
 
 	// TODO: remove default for release
 	AesKey string `help:"AES256 encryption key to encrypt notification configs at rest" default:"D4BEC3EA5794EE0F38B21B9D4EC69F17F295C62618AB7F2C74814190F1F41ACC"`

--- a/main.go
+++ b/main.go
@@ -122,6 +122,17 @@ func run(d *deps.Dependencies) error {
 		}
 	}()
 
+	// Tail/peek consumers are separate from the main consumer to avoid
+	// bogging down the main consumer with traffic during a peek
+	for i := 0; i <= d.Config.NumTailConsumers; i++ {
+		go func() {
+			if err := d.BusService.RunTailConsumer(); err != nil {
+				errChan <- errors.Wrap(err, "error during RedisBackend tail consumer run")
+				return
+			}
+		}()
+	}
+
 	displayInfo(d)
 
 	if d.Config.SeedDummyData {

--- a/services/bus/broadcast.go
+++ b/services/bus/broadcast.go
@@ -2,6 +2,7 @@ package bus
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -124,13 +125,25 @@ func (b *Bus) BroadcastTailRequest(ctx context.Context, req *protos.TailRequest)
 }
 
 func (b *Bus) BroadcastTailResponse(ctx context.Context, resp *protos.TailResponse) error {
-	// TODO: this should probably go over a unique stream based on the TailRequestID
-	// TODO: but that will involve creating the stream and then cleaning up the stream after the TailRequest is complete
-	return b.broadcast(ctx, "tail", &protos.BusEvent{
+	event := &protos.BusEvent{
 		Event: &protos.BusEvent_TailResponse{
 			TailResponse: resp,
 		},
-	})
+		XMetadata: util.CtxMetadata(ctx),
+		Source:    b.options.NodeName,
+	}
+
+	data, err := proto.Marshal(event)
+	if err != nil {
+		return errors.Wrap(err, "error marshaling bus message")
+	}
+
+	topic := fmt.Sprintf("%s:%s", TailSubjectPrefix, resp.TailRequestId)
+	if err := b.options.RedisBackend.Publish(ctx, topic, data).Err(); err != nil {
+		return errors.Wrap(err, "error publishing tail response")
+	}
+
+	return nil
 }
 
 // TODO: Use generics

--- a/services/bus/handlers.go
+++ b/services/bus/handlers.go
@@ -494,7 +494,9 @@ func (b *Bus) sendTailCommand(ctx context.Context, req *protos.TailRequest) erro
 	// Find registered clients
 	// There may be multiple instances connected to the same snitch server instance with
 	// the same pipeline ID and audience
-	live, err := b.options.Store.GetLive(ctx)
+	// This needs to be it's own context since the parent context will be canceled on shutdown and
+	// thus we won't be able to read from redis in order to send out stop commands
+	live, err := b.options.Store.GetLive(context.Background())
 	if err != nil {
 		return errors.Wrap(err, "unable to get live SDK connections")
 	}


### PR DESCRIPTION
* This also fixes a bug where Bus consumers were not shutting down because `redis.ReceiveMessage()` doesn't respect context cancelation