### PR TITLE
Fix tail/peek

### DIFF
--- a/apis/grpcapi/internal.go
+++ b/apis/grpcapi/internal.go
@@ -458,7 +458,7 @@ func (s *InternalServer) SendTail(srv protos.Internal_SendTailServer) error {
 				continue
 			}
 
-			s.log.Infof("publishing tail response for session id '%s'", tailResp.SessionId)
+			s.log.Debugf("publishing tail response for session id '%s'", tailResp.SessionId)
 		}
 	}
 }

--- a/apis/grpcapi/internal.go
+++ b/apis/grpcapi/internal.go
@@ -363,7 +363,9 @@ func (s *InternalServer) NewAudience(ctx context.Context, req *protos.NewAudienc
 		s.log.Debugf("channel already exists for session id '%s'", req.SessionId)
 	}
 
-	go s.sendInferSchemaPipelines(ctx, cmdCh, req.SessionId)
+	// This is context.Background() because it's ran as a gouroutine and the request
+	// context may be finished by the time it eventually runs
+	go s.sendInferSchemaPipelines(context.Background(), cmdCh, req.SessionId)
 
 	// Broadcast audience creation so that we can notify UI GetAllStream clients
 	if err := s.Options.BusService.BroadcastNewAudience(ctx, req); err != nil {

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -205,14 +205,15 @@ func (d *Dependencies) setupServices(cfg *config.Config) error {
 	d.PubSubService = pubsub.New()
 
 	busService, err := bus.New(&bus.Options{
-		Store:        storeService,
-		RedisBackend: d.RedisBackend,
-		Cmd:          d.CmdService,
-		NodeName:     d.Config.NodeName,
-		ShutdownCtx:  d.ShutdownContext,
-		WASMDir:      d.Config.WASMDir,
-		Metrics:      d.MetricsService,
-		PubSub:       d.PubSubService,
+		Store:            storeService,
+		RedisBackend:     d.RedisBackend,
+		Cmd:              d.CmdService,
+		NodeName:         d.Config.NodeName,
+		ShutdownCtx:      d.ShutdownContext,
+		WASMDir:          d.Config.WASMDir,
+		Metrics:          d.MetricsService,
+		PubSub:           d.PubSubService,
+		NumTailConsumers: cfg.NumTailConsumers,
 	})
 	if err != nil {
 		return errors.Wrap(err, "unable to create new bus service")

--- a/main.go
+++ b/main.go
@@ -124,14 +124,11 @@ func run(d *deps.Dependencies) error {
 
 	// Tail/peek consumers are separate from the main consumer to avoid
 	// bogging down the main consumer with traffic during a peek
-	for i := 0; i <= d.Config.NumTailConsumers; i++ {
-		go func() {
-			if err := d.BusService.RunTailConsumer(); err != nil {
-				errChan <- errors.Wrap(err, "error during RedisBackend tail consumer run")
-				return
-			}
-		}()
-	}
+	go func() {
+		if err := d.BusService.RunTailConsumer(); err != nil {
+			errChan <- errors.Wrap(err, "error during RedisBackend consumer run")
+		}
+	}()
 
 	displayInfo(d)
 

--- a/services/bus/bus.go
+++ b/services/bus/bus.go
@@ -212,7 +212,7 @@ func (b *Bus) RunTailConsumer() error {
 	}
 
 	// This channel is shared between all tail workers
-	sharedWorkerCh := make(chan *redis.Message, 3)
+	sharedWorkerCh := make(chan *redis.Message, b.options.NumTailConsumers)
 
 	// Start workers
 	for i := 0; i < b.options.NumTailConsumers; i++ {


### PR DESCRIPTION
* Prevent TailResponse message duplication by only having one reader for "snitch_events:tail:*"
* When a tail request is stopped, close all internal pubsub channels that are used to communicate between `bus.handleTailResponse()` -> `external.Tail()`
* Fix context race condition when sending inferschema pipeline for a NewAudience() call